### PR TITLE
Remove React 18 as a valid peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vesselapi/react-vessel-link",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "A React component to open the Vessel Connect Modal",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
@@ -67,8 +67,8 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.2 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.2 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.2",
+    "react-dom": "^16.8.0 || ^17.0.2"
   },
   "tags": [
     "react",


### PR DESCRIPTION
I was mistaken about React 18 being a supported version, looks like the changes are more substantial than I thought and when I was using the package in a React 18 environment things were breaking. Bumping the version down to be safe for now, will investigate bumping it back up in the future. 