### PR TITLE
feat: return loading prop from useVesselLink

### DIFF
--- a/src/useVesselLink.ts
+++ b/src/useVesselLink.ts
@@ -39,5 +39,6 @@ export default function useVesselLink(config: ClientConfig) {
   return {
     error,
     open,
+    loading: !popupLoaded,
   };
 }


### PR DESCRIPTION
this simplifies the process of waiting for the popup to load prior to allowing open to be called

> note: feel free to modify, this is just a potential proposal for simplifying waiting for loading to complete